### PR TITLE
time accuracy and kubectl prefix

### DIFF
--- a/bin/json-log-pp
+++ b/bin/json-log-pp
@@ -22,7 +22,9 @@ end
 while line = STDIN.gets
   break if line == nil
 
-  json = JSON.parse(line) rescue nil
+  line_without_prefix = line.sub /^(.+)\sweb\s/, ''
+
+  json = JSON.parse(line_without_prefix) rescue nil
 
   json = json['data'] if json && json['data']
 

--- a/lib/rack-json-logs.rb
+++ b/lib/rack-json-logs.rb
@@ -63,7 +63,7 @@ module Rack
 
       log = {
         time:     start_time.to_i,
-        duration: (Time.now - start_time).round(3),
+        duration: (Time.now - start_time),
         request:  "#{env['REQUEST_METHOD']} #{env['PATH_INFO']}",
         status:   (response || [500]).first,
         from:     @options[:from],
@@ -114,7 +114,7 @@ module Rack
         @events << {
           type:  type,
           value: value,
-          time:  (Time.now - @start_time).round(3)
+          time:  (Time.now - @start_time)
         }
       end
     end

--- a/lib/rack-json-logs/pretty-printer.rb
+++ b/lib/rack-json-logs/pretty-printer.rb
@@ -26,7 +26,7 @@ module Rack
       resp = 'Response: '
       resp << "#{json['status']} " if json['status']
       if opts[:duration] && json['duration']
-        resp << "(#{(json['duration']*1000).round}ms) "
+        resp << "(#{(json['duration'])}ms) "
       end
 
       out.puts '     * * *'
@@ -34,7 +34,7 @@ module Rack
       out.puts "Request: #{json['request']}".cyan
       out.puts resp.send(status_color)
       out.puts "From: #{json['from']}".cyan if opts[:from] && json['from']
-      out.puts "At: #{Time.at(json['time']).strftime('%b %-e %Y, %-l:%M%P')}"
+      out.puts "At: #{Time.at(json['time']).strftime('%b %-e %Y, %-l:%M:%S:%L%P')}"
       out.puts
 
       %w{stdout stderr}.each do |b|
@@ -55,7 +55,7 @@ module Rack
         out.puts
         json['events'].each do |e|
           out.puts "Event: #{e['type']}"
-          out.puts "At: #{(e['time']*1000).round}ms"
+          out.puts "At: #{(e['time'])}ms"
           out.puts "Value: #{e['value'].to_json}"
           out.puts
         end


### PR DESCRIPTION
some minor changes to increase the granularity of the time stamps and allow us to work with stern which prefixes log items with the kubernetes pod that the log is from